### PR TITLE
Wait for Logs before Exiting

### DIFF
--- a/Sources/Client/GameClient.swift
+++ b/Sources/Client/GameClient.swift
@@ -168,7 +168,7 @@ public class GameClient: WebSocketDelegate {
     private func log(error: Error) {
         
         func logDefault() {
-            log.print(error.localizedDescription, for: .errors)
+            log.print("\(error)", for: .errors)
         }
         
         let error = error as NSError

--- a/Sources/Client/GameLoop.swift
+++ b/Sources/Client/GameLoop.swift
@@ -93,6 +93,7 @@ public class GameLoop {
                 processFrame()
                 continue runLoop
             case .off:
+                client.log.waitUntilDoneLogging()
                 break runLoop
             }
         }

--- a/Sources/PlayerSupport/Log.swift
+++ b/Sources/PlayerSupport/Log.swift
@@ -89,6 +89,11 @@ public class Log {
         }
     }
     
+    /// Blocks the current thread until any pending log messages have been logged.
+    public func waitUntilDoneLogging() {
+        serialQueue.sync {}
+    }
+    
     /// A collection of mix-and-match log types
     public struct LogTypes: OptionSet {
         


### PR DESCRIPTION
Don't return from the main thread until the logging thread has finished printing any pending messages such as errors.