### PR TITLE
Disallow Multiple Commands per Frame

### DIFF
--- a/Sources/Client/GameLoop.swift
+++ b/Sources/Client/GameLoop.swift
@@ -173,7 +173,7 @@ public class GameLoop {
         
         // Make move if needed
         if gameState.isGameOngoing && gameState.myTank.isAlive {
-            for command in player.makeMove(withGameState: gameState) {
+            if let command = player.makeMove(withGameState: gameState) {
                 if updateGameState(for: command) {
                     client.send(command: command)
                 }

--- a/Sources/PlayerSupport/Player.swift
+++ b/Sources/PlayerSupport/Player.swift
@@ -46,9 +46,9 @@ public protocol Player {
      
      - parameter gameState: The updated game state
      
-     - returns: An optional list of commands for the tank to execute in order
+     - returns: An optional command for the tank to execute in order
      */
-    mutating func makeMove(withGameState gameState: GameState) -> [Command]
+    mutating func makeMove(withGameState gameState: GameState) -> Command?
     
     /**
      Called when the player's tank is killed.


### PR DESCRIPTION
Server only executes one command per client per frame, so sending multiple commands per frame from a single client can cause a command backlog that will cause odd behavior. Players should only be able to send 0 or 1 commands per frame.

This is a breaking change for clients, so it can't land till 2.0 to avoid breaking dependents.