### PR TITLE
Store FPS in GameConfiguration

### DIFF
--- a/Sources/ClientControl/Game.swift
+++ b/Sources/ClientControl/Game.swift
@@ -39,7 +39,7 @@ public struct Game {
             exit(1)
         }
         
-        let gameConfig = GameConfiguration()
+        let gameConfig = GameConfiguration(fps: clientConfig.framesPerSecond)
         
         let client = GameClient(configuration: clientConfig)
         

--- a/Sources/PlayerSupport/GameConfiguration.swift
+++ b/Sources/PlayerSupport/GameConfiguration.swift
@@ -17,7 +17,7 @@ public struct GameConfiguration {
     
     /// The FPS rate that will be maintained in an ideal scenario where processing doesn't take longer than it's supposed to.
     ///
-    /// This value can be useful to the player so that time may be mapped to frames and vice/versa.
+    /// This value can be useful to the player so that time may be mapped to frames and vice versa.
     public let targetFramesPerSecond: Int
     
     /// A configuration for the map

--- a/Sources/PlayerSupport/GameConfiguration.swift
+++ b/Sources/PlayerSupport/GameConfiguration.swift
@@ -15,6 +15,11 @@
  */
 public struct GameConfiguration {
     
+    /// The FPS rate that will be maintained in an ideal scenario where processing doesn't take longer than it's supposed to.
+    ///
+    /// This value can be useful to the player so that time may be mapped to frames and vice/versa.
+    public let targetFramesPerSecond: Int
+    
     /// A configuration for the map
     public let map = MapConfig()
     
@@ -25,7 +30,9 @@ public struct GameConfiguration {
     public let shell = ShellConfig()
     
     /// Creates a `GameConfiguration` with required values.
-    public init() {}
+    public init(fps: Int) {
+        self.targetFramesPerSecond = fps
+    }
     
     /**
      Represents a configuration for a game map. These values match with the server and are therefore immutable.

--- a/Sources/PlayerSupport/GameConfiguration.swift
+++ b/Sources/PlayerSupport/GameConfiguration.swift
@@ -30,6 +30,8 @@ public struct GameConfiguration {
     public let shell = ShellConfig()
     
     /// Creates a `GameConfiguration` with required values.
+    ///
+    /// - Parameter fps: The target frame rate for this game.
     public init(fps: Int) {
         self.targetFramesPerSecond = fps
     }


### PR DESCRIPTION
The target FPS is copied into the `GameConfiguration` from the `ClientConfiguration` so that the `Player` has access to it. This can help with mapping time to frames and vice/versa for clients.